### PR TITLE
Replace armor stand text with rendered text text

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.14.22
 fabric_kotlin_version=1.9.3+kotlin.1.8.20
 
 # Mod Properties
-mod_version=1.4-beta
+mod_version=fabric_1.4-beta+1.20.1
 maven_group=com.bloodfall.cobblemonspawns
 archives_base_name=cobblemonspawns
 

--- a/src/main/java/com/bloodfall/cobblemonspawns/CobblemonSpawns.java
+++ b/src/main/java/com/bloodfall/cobblemonspawns/CobblemonSpawns.java
@@ -28,14 +28,14 @@ public class CobblemonSpawns implements ModInitializer {
     public static final String MOD_ID = "cobblemonspawns";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
-    public static final Identifier START_BOUNDING_BOX_PACKET_ID = new Identifier("cobblemonspawns", "start_bounding_box");
-    public static final Identifier STOP_BOUNDING_BOX_PACKET_ID = new Identifier("cobblemonspawns", "stop_bounding_box");
-
     public static final Identifier DELETE_AREA_PACKET_ID = new Identifier(MOD_ID, "delete_area");
     public static final Identifier UPDATE_AREA_PACKET_ID = new Identifier(MOD_ID, "update_area");
     public static final Identifier OPEN_AREA_GUI_PACKET_ID = new Identifier(MOD_ID, "open_area_gui");
-
     public static final Identifier REFRESH_DEBUG_VIEW_PACKET = new Identifier(MOD_ID, "refresh_debug_view");
+    public static final Identifier START_BOUNDING_BOX_PACKET_ID = new Identifier("cobblemonspawns", "start_bounding_box");
+    public static final Identifier STOP_BOUNDING_BOX_PACKET_ID = new Identifier("cobblemonspawns", "stop_bounding_box");
+    public static final Identifier FLOATING_TEXT_PACKET_ID = new Identifier(MOD_ID, "floating_text");
+    public static final Identifier CLEAR_FLOATING_TEXT_PACKET_ID = new Identifier(MOD_ID, "clear_floating_text");
 
     public static ServerWorld sWorld;
 
@@ -44,12 +44,10 @@ public class CobblemonSpawns implements ModInitializer {
     {
         registerModItems();
 
-        // Register the /area commands
         CommandRegistrationCallback.EVENT.register((dispatcher, dedicated, environment) -> {
             AreaCommands.register(dispatcher);
         });
 
-        // Register player tick event for movement tracking
         ServerTickEvents.END_WORLD_TICK.register(world -> {
             if (!world.isClient()) {
                 AreaManager manager = AreaManager.get(world);
@@ -151,6 +149,13 @@ public class CobblemonSpawns implements ModInitializer {
 
                 // Perform the refreshDebugView action
                 AreaCommands.refreshDebugView(server.getOverworld(), player);
+            });
+        });
+
+        ServerPlayNetworking.registerGlobalReceiver(CLEAR_FLOATING_TEXT_PACKET_ID, (server, player, handler, buf, responseSender) -> {
+            server.execute(() -> {
+                // You can handle additional logic here if needed
+                // For now, it's just a signal to the client to clear texts
             });
         });
     }

--- a/src/main/java/com/bloodfall/cobblemonspawns/client/BoundingBoxRenderer.java
+++ b/src/main/java/com/bloodfall/cobblemonspawns/client/BoundingBoxRenderer.java
@@ -38,7 +38,7 @@ public class BoundingBoxRenderer {
         VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getLines());
 
         for (Box box : boundingBoxes) {
-            drawBoxLines(matrices, vertexConsumer, box, 0.0F, 1.0F, 0.0F, 1.0F); // Red color
+            drawBoxLines(matrices, vertexConsumer, box, 1.0F, 1.0F, 1.0F, 1.0F);
         }
 
         matrices.pop();

--- a/src/main/java/com/bloodfall/cobblemonspawns/client/FloatingText.java
+++ b/src/main/java/com/bloodfall/cobblemonspawns/client/FloatingText.java
@@ -1,0 +1,21 @@
+package com.bloodfall.cobblemonspawns.client;
+
+import net.minecraft.util.math.BlockPos;
+
+public class FloatingText {
+    private final String text;
+    private final BlockPos position;
+
+    public FloatingText(String text, BlockPos position) {
+        this.text = text;
+        this.position = position;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public BlockPos getPosition() {
+        return position;
+    }
+}

--- a/src/main/java/com/bloodfall/cobblemonspawns/client/FloatingTextRenderer.java
+++ b/src/main/java/com/bloodfall/cobblemonspawns/client/FloatingTextRenderer.java
@@ -1,0 +1,116 @@
+package com.bloodfall.cobblemonspawns.client;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.client.render.Camera;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import org.joml.Quaternionf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FloatingTextRenderer {
+    private static final List<FloatingText> floatingTexts = new ArrayList<>();
+
+    public static void setFloatingTexts(List<FloatingText> texts) {
+        floatingTexts.clear();
+        floatingTexts.addAll(texts);
+    }
+
+    public static void clearFloatingTexts() {
+        floatingTexts.clear();
+    }
+
+    public static void render(WorldRenderContext context) {
+        if (floatingTexts.isEmpty()) return;
+
+        MatrixStack matrices = context.matrixStack();
+        Camera camera = context.camera();
+        double camX = camera.getPos().x;
+        double camY = camera.getPos().y;
+        double camZ = camera.getPos().z;
+
+        matrices.push();
+        matrices.translate(-camX, -camY, -camZ);
+
+        for (FloatingText text : floatingTexts) {
+            BlockPos pos = text.getPosition();
+            double x = pos.getX();
+            double y = pos.getY();
+            double z = pos.getZ();
+
+            double distanceSquared = (x - camera.getPos().x) * (x - camera.getPos().x)
+                                    + (y - camera.getPos().y) * (y - camera.getPos().y)
+                                    + (z - camera.getPos().z) * (z - camera.getPos().z);
+            double MAX_RENDER_DISTANCE_SQUARED = 100 * 100;
+
+            if (distanceSquared > MAX_RENDER_DISTANCE_SQUARED) {
+                continue;
+            }
+
+            double dx = camX - x;
+            double dy = camY - y;
+            double dz = camZ - z;
+
+            double distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+            if (distance == 0) distance = 0.0001;
+
+            float yaw = (float) Math.toDegrees(Math.atan2(dz, dx)) - 90.0F;
+            float pitch = (float) Math.toDegrees(Math.asin(dy / distance));
+
+            matrices.push();
+            matrices.translate(x, y, z);
+
+            //float yaw = camera.getYaw();
+            //float pitch = camera.getPitch();
+
+            Quaternionf yawRotation = new Quaternionf().rotateY((float) Math.toRadians(-yaw));
+            Quaternionf  pitchRotation = new Quaternionf().rotateX((float) Math.toRadians(-pitch));
+
+            matrices.multiply(yawRotation);
+            matrices.multiply(pitchRotation);
+
+            matrices.scale(0.02F, -0.02F, 0.02F);
+
+            TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
+
+            String[] lines = text.getText().split("\n");
+            int lineHeight = textRenderer.fontHeight;
+
+            boolean setShadow = false;
+
+            // Iterate through each line and render it
+            for (int i = 0; i < lines.length; i++) {
+                String line = lines[i];
+
+
+                setShadow = i == 0;
+
+                // Calculate text width to center it
+                float textWidth = textRenderer.getWidth(line);
+
+                // Y offset for each line to stack them vertically
+                float yOffset = i * lineHeight;
+
+                // Draw the text centered horizontally and stacked vertically
+                textRenderer.draw(
+                        line,
+                        -textWidth / 2.0f, -lineHeight / 2.0f + yOffset, 0xFFFFFF,
+                        setShadow,
+                        matrices.peek().getPositionMatrix(),
+                        MinecraftClient.getInstance().getBufferBuilders().getEntityVertexConsumers(),
+                        TextRenderer.TextLayerType.NORMAL,
+                        0,
+                        15728880
+                );
+            }
+
+            matrices.pop();
+        }
+
+        matrices.pop();
+    }
+}


### PR DESCRIPTION
- Text is now rendered with graphical rendering methods
    - More efficient and stable
    - Text is destroyed when the client leaves, preferable over having armor stands hang out between log-in instances
